### PR TITLE
Fixed environment variables references in Caddyfile.tmpl

### DIFF
--- a/Caddyfile.tmpl
+++ b/Caddyfile.tmpl
@@ -6,16 +6,16 @@ log {
 
 route {
 	s3browser {
-		site_name "${S3_SITENAME}" # S3 Browser
-		endpoint "${S3_ENDPOINT}"
-		region "${S3_REGION}"
-		key "${S3_KEY}"
-		secret "${S3_SECRET}"
-		secure ${S3_SECURE} # true
-		bucket "${S3_BUCKET}"
-		refresh_interval "${S3_REFRESH}" # 5m
-		refresh_api_secret "${S3_REFRESH_SECRET}"
-		debug "${S3_DEBUG}" # false
-		signed_url_redirect ${S3_SIGNED_URL_REDIRECT} # false
+		site_name "{$S3_SITENAME}" # S3 Browser
+		endpoint "{$S3_ENDPOINT}" # Endpoint of S3, don't include scheme
+		region "{$S3_REGION}"
+		key "{$S3_KEY}"
+		secret "{$S3_SECRET}"
+		secure {$S3_SECURE} # true
+		bucket "{$S3_BUCKET}"
+		refresh_interval "{$S3_REFRESH}" # 5m
+		refresh_api_secret "{$S3_REFRESH_SECRET}"
+		debug "{$S3_DEBUG}" # false
+		signed_url_redirect {$S3_SIGNED_URL_REDIRECT} # false
 	}
 }


### PR DESCRIPTION
Hello, I fixed some mistakes in the template Caddyfile. Environment variables should be reference as {$<name of env var>}, as described in https://caddyserver.com/docs/caddyfile/concepts#environment-variables.

Thanks!